### PR TITLE
patch-fix-links-to-the-OpenSTEF-community-wide-files-in-openstf-repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This project is licensed under the Mozilla Public License, version 2.0 - see LIC
 This project includes third-party libraries, which are licensed under their own respective Open-Source licenses. SPDX-License-Identifier headers are used to show which license is applicable. The concerning license files can be found in the LICENSES directory.
 
 ## Contributing
-Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](CONTRIBUTING.md) for details on the process for submitting pull requests to us.
+Please read [CODE_OF_CONDUCT.md](https://github.com/OpenSTEF/.github/blob/main/CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](https://github.com/OpenSTEF/.github/blob/main/CONTRIBUTING.md) for details on the process for submitting pull requests to us.
 
 ## Contact
-N.V. Alliander - Team Korte Termijn Prognoses (Short Term Forecasting) <korte.termijn.prognoses@alliander.com>
+Please read [SUPPORT.md](https://github.com/OpenSTEF/.github/blob/main/SUPPORT.md) for how to connect and get into contact with the OpenSTF project


### PR DESCRIPTION
1) Updated the location of the CODE_OF_CONDUCT.md and CONTRIBUTING.md file. The current links were broken. 
2) Refered to SUPPORT.md for contact information.